### PR TITLE
Optimize NodeJS function warm starts by enabling TCP connection reuse

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -158,6 +158,9 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref BooksTable
       Timeout: 10
+      Environment:
+        Variables:
+          AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
 
       Events:
         CreateBook:


### PR DESCRIPTION
The AWS SDK variant that is available by default on Lambda runtime's is
v2. This version creates and closes a new TCP connection for each
network request. For backwards compatibility reasons, [they didn't change
that default behavior in v2][0], but [they did in v3][1].

However, this can be manually set in by passing in a configured http
Agent to the AWS SDK with `keepAlive` set to `true` or by simply [setting
the `AWS_NODEJS_CONNECTION_REUSE_ENABLED` environment variable][2].

While this shouldn't really impact cold starts much, the performance
difference when measuring warm starts can be pretty significant. This is
a relevant excerpt from the AWS documentation:

> By default, the default Node.js HTTP/HTTPS agent creates a new TCP
> connection for every new request. To avoid the cost of establishing a
> new connection, you can reuse an existing connection.
>
> For short-lived operations, such as DynamoDB queries, the latency
> overhead of setting up a TCP connection might be greater than the
> operation itself. Additionally, since DynamoDB encryption at rest is
> integrated with AWS KMS, you may experience latencies from the
> database having to re-establish new AWS KMS cache entries for each
> operation.

  [0]: https://github.com/aws/aws-sdk-js/issues/2571
  [1]: https://aws.amazon.com/blogs/developer/http-keep-alive-is-on-by-default-in-modular-aws-sdk-for-javascript/
  [2]: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html