### PR TITLE
Use System.Text.Json as the Lambda serializer

### DIFF
--- a/dotnet-lambda/src/DotNetFunction/DotNetFunction.csproj
+++ b/dotnet-lambda/src/DotNetFunction/DotNetFunction.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="1.2.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.Json" Version="1.5.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.60" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.0.83" />
   </ItemGroup>
 </Project>
 

--- a/dotnet-lambda/src/DotNetFunction/Function.cs
+++ b/dotnet-lambda/src/DotNetFunction/Function.cs
@@ -5,11 +5,10 @@ using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
-using JsonSerializer = Amazon.Lambda.Serialization.Json.JsonSerializer;
 
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
-[assembly: LambdaSerializer(typeof(JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
 namespace DotNetFunction
 {


### PR DESCRIPTION
The previous PR https://github.com/Aleksandr-Filichkin/aws-lambda-runtimes-performance/pull/8 changed the usage of Newtonsoft to System.Text.Json in the actual Lambda function. This PR registers the System.Text.Json based Lambda serializer as the serializer for Lambda event and return objects.  

A big thing to help reduce .NET cold starts is remove all usages of Newtonsoft because loading that large assembly is very costly.