### PR TITLE
Invoke Rust single threaded

### DIFF
--- a/rust-aws-lambda/src/main.rs
+++ b/rust-aws-lambda/src/main.rs
@@ -24,7 +24,7 @@ lazy_static! {
 }
 
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Error> {
     SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
     lambda_runtime::run(handler(func)).await?;


### PR DESCRIPTION
Implementing [the suggestion to make tokio invoke single threaded](https://medium.com/@ionionascu/the-rust-code-is-not-optimal-68baf5c2ae69?source=responses-----c1b441005fd1----7-------------------------------) in Rust as seen here: 

[tokio library doc reference](https://docs.rs/tokio/1.13.1/tokio/attr.main.html#current-thread-runtime)

Closes #16.